### PR TITLE
Add call availability interface

### DIFF
--- a/src/android/CFCallNumber.java
+++ b/src/android/CFCallNumber.java
@@ -32,10 +32,16 @@ public class CFCallNumber extends CordovaPlugin {
     this.callbackContext = callbackContext;
     this.executeArgs = args;
 
-    if (cordova.hasPermission(CALL_PHONE)) {
-      callPhone(executeArgs);
+    if (action.equals("callNumber")) {
+      if (cordova.hasPermission(CALL_PHONE)) {
+        callPhone(executeArgs);
+      } else {
+        getCallPermission(CALL_REQ_CODE);
+      }
+    } else if (action.equals("isCallSupported")) {
+        this.callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, isTelephonyEnabled()));
     } else {
-      getCallPermission(CALL_REQ_CODE);
+      return false;
     }
 
     return true;

--- a/src/ios/CFCallNumber.h
+++ b/src/ios/CFCallNumber.h
@@ -3,5 +3,6 @@
 @interface CFCallNumber : CDVPlugin
 
 - (void) callNumber:(CDVInvokedUrlCommand*)command;
+- (void) isCallSupported:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/CFCallNumber.m
+++ b/src/ios/CFCallNumber.m
@@ -3,6 +3,10 @@
 
 @implementation CFCallNumber
 
++ (BOOL)available {
+    return [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:@"tel://"]];
+}
+
 - (void) callNumber:(CDVInvokedUrlCommand*)command {
 
     [self.commandDelegate runInBackground:^{
@@ -15,7 +19,7 @@
             number =  [NSString stringWithFormat:@"tel:%@", number];
         }
 
-        if(![[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:number]]) {
+        if(![CFCallNumber available]) {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"NoFeatureCallSupported"];
         }
         else if(![[UIApplication sharedApplication] openURL:[NSURL URLWithString:number]]) {
@@ -28,6 +32,15 @@
         // return result
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 
+    }];
+}
+
+- (void) isCallSupported:(CDVInvokedUrlCommand*)command {
+    [self.commandDelegate runInBackground: ^{
+        CDVPluginResult* pluginResult = [CDVPluginResult
+            resultWithStatus:CDVCommandStatus_OK
+            messageAsBool:[CFCallNumber available]];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
 }
 

--- a/www/CallNumber.js
+++ b/www/CallNumber.js
@@ -4,6 +4,10 @@ CallNumber.prototype.callNumber = function(success, failure, number, bypassAppCh
     cordova.exec(success, failure, "CallNumber", "callNumber", [number, bypassAppChooser]);
 };
 
+CallNumber.prototype.isCallSupported = function(success, failure){
+    cordova.exec(success, failure, "CallNumber", "isCallSupported");
+}
+
 //Plug in to Cordova
 cordova.addConstructor(function() {
 


### PR DESCRIPTION
This feature helps users before-hand to check if calling is supported, without having to trigger the call. In some cases, it may be useful to hide the button performing the call from in-app. Please do take a look.