### PR TITLE
Fix Android package name

### DIFF
--- a/src/android/CFCallNumber.java
+++ b/src/android/CFCallNumber.java
@@ -1,4 +1,4 @@
-package mx.ferreyra.callnumber;
+package com.rohithvaranasi.callnumber;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;


### PR DESCRIPTION
This pull request fixes the following issue:

The package path declared [in plugin.xml](https://github.com/Rohfosho/CordovaCallNumberPlugin/blob/master/plugin.xml#L43) is `com/rohithvaranasi/callnumber` but the package name declared in [CFCallNumber.java](https://github.com/Rohfosho/CordovaCallNumberPlugin/blob/master/src/android/CFCallNumber.java#L1) is `mx.ferreyra.callnumber` which results in the Java error:

    Package name 'mx.ferreyra.callnumber' does not correspond to the file path 'com.rohithvaranasi.callnumber'

This causes the plugin not to work because Cordova cannot find the plugin class to call.