### PR TITLE
Align version in plugin.xml vs package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "call-number",
-  "version": "1.0.1",
+  "version": "1.0.4",
   "description": "Call Number from Cordova Application",
   "cordova": {
     "id": "call-number",

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
   xmlns="http://apache.org/cordova/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
   id="call-number"
-  version="0.0.2">
+  version="1.0.4">
 
   <description>Call Number from Cordova Application</description>
 


### PR DESCRIPTION
since it causes problems with Cordova CLI which uses both:

    Discovered plugin "call-number" in config.xml. Adding it to the project
    Failed to restore plugin "call-number" from config.xml. You might need to try adding it again. Error: Failed to fetch plugin https://github.com/Rohfosho/CordovaCallNumberPlugin via registry.
    Probably this is either a connection problem, or plugin spec is incorrect.
    Check your connection and plugin name/version/URL.
    Failed to get absolute path to installed module