### PR TITLE
[android][solve : #79] User can select Call direct or Go to Dial

### DIFF
--- a/src/android/CFCallNumber.java
+++ b/src/android/CFCallNumber.java
@@ -86,7 +86,7 @@ public class CFCallNumber extends CordovaPlugin {
     }
   }
   private String CallDirect(boolean type) {
-    return type ? Intent.ACTION_CALL : Intent.ACTION_DIAL;
+    return type ? Intent.ACTION_DIAL : Intent.ACTION_CALL;
   }
 
   private boolean isTelephonyEnabled() {

--- a/src/android/CFCallNumber.java
+++ b/src/android/CFCallNumber.java
@@ -72,7 +72,7 @@ public class CFCallNumber extends CordovaPlugin {
     try {
       boolean bypassAppChooser = Boolean.parseBoolean(args.getString(1));
 
-      Intent intent = new Intent(isTelephonyEnabled() ? CallDirect(bypassAppChooser) : Intent.ACTION_VIEW);
+      Intent intent = new Intent(isTelephonyEnabled() ? gotoDialer(bypassAppChooser) : Intent.ACTION_VIEW);
       intent.setData(Uri.parse(number));
       
       if (bypassAppChooser) {
@@ -85,7 +85,7 @@ public class CFCallNumber extends CordovaPlugin {
       callbackContext.error("CouldNotCallPhoneNumber");
     }
   }
-  private String CallDirect(boolean type) {
+  private String gotoDialer(boolean type) {
     return type ? Intent.ACTION_DIAL : Intent.ACTION_CALL;
   }
 

--- a/src/android/CFCallNumber.java
+++ b/src/android/CFCallNumber.java
@@ -70,10 +70,11 @@ public class CFCallNumber extends CordovaPlugin {
       number = String.format("tel:%s", number);
     }
     try {
-      Intent intent = new Intent(isTelephonyEnabled() ? Intent.ACTION_CALL : Intent.ACTION_VIEW);
-      intent.setData(Uri.parse(number));
-
       boolean bypassAppChooser = Boolean.parseBoolean(args.getString(1));
+
+      Intent intent = new Intent(isTelephonyEnabled() ? CallDirect(bypassAppChooser) : Intent.ACTION_VIEW);
+      intent.setData(Uri.parse(number));
+      
       if (bypassAppChooser) {
         intent.setPackage(getDialerPackage(intent));
       }
@@ -83,6 +84,9 @@ public class CFCallNumber extends CordovaPlugin {
     } catch (Exception e) {
       callbackContext.error("CouldNotCallPhoneNumber");
     }
+  }
+  private String CallDirect(boolean type) {
+    return type ? Intent.ACTION_CALL : Intent.ACTION_DIAL;
   }
 
   private boolean isTelephonyEnabled() {


### PR DESCRIPTION
i solve #79 Is it possible to populate the phone number but not dial?

as you know, isTelephonyEnabled is only work when TelephonyManager is not PHONE_TYPE_NONE
`tm.getPhoneType() != TelephonyManager.PHONE_TYPE_NONE`

and user manually can't go Call Dial. 
so i revise Intent for User who can select Call Directly or Go to Dial
`Intent intent = new Intent(isTelephonyEnabled() ? gotoDialer(bypassAppChooser) : Intent.ACTION_VIEW);`

and make a function CallDirect()
`  private String gotoDialer(boolean type) {
    return type ? Intent.ACTION_DIAL : Intent.ACTION_CALL;
  }
`
NOW user can go dial when bypassAppChooser is **true**