### PR TITLE
Fixed config.xml target path

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -31,7 +31,7 @@
   </platform>
 
   <platform name="android">
-      <config-file target="app/src/main/res/xml/config.xml" parent="/*">
+      <config-file target="res/xml/config.xml" parent="/*">
           <feature name="CallNumber">
               <param name="android-package" value="com.rohithvaranasi.callnumber.CFCallNumber"/>
           </feature>


### PR DESCRIPTION
Target path cannot be resolved properly, thus Android package is not written to config.xml file. Tested with Cordova 9, Android Studio 3.6.1. Adjustment of target path fixes the issue.